### PR TITLE
Add skip_noqa argument to skip "noqa"-commented lines (fix #2)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,7 @@ Options:
 * `-h`, `--help`: display help message and exit
 * `-c`, `--no-compile`: do not check compilation of file (with `msgfmt -c`)
 * `-f`, `--fuzzy`: check fuzzy strings
+* `-n`, `--skip-noqa`: do not check "noqa"-commented lines
 * `-l`, `--no-lines`: do not check number of lines
 * `-p`, `--no-punct`: do not check punctuation at end of strings
 * `-s id|str`, `--spelling id|str`: check spelling (`id` = source messages,

--- a/msgcheck/msgcheck.py
+++ b/msgcheck/msgcheck.py
@@ -65,6 +65,8 @@ The script returns:
                         help='do not check compilation of file')
     parser.add_argument('-f', '--fuzzy', action='store_true',
                         help='check fuzzy strings')
+    parser.add_argument('-n', '--skip-noqa', action='store_true',
+                        help='do not check "noqa"-commented lines')
     parser.add_argument('-l', '--no-lines', action='store_true',
                         help='do not check number of lines')
     parser.add_argument('-p', '--no-punct', action='store_true',
@@ -112,7 +114,7 @@ def main():
 
     # create checker and set boolean options
     po_check = PoCheck()
-    for option in ('no_compile', 'fuzzy', 'no_lines', 'no_punct',
+    for option in ('no_compile', 'fuzzy', 'skip_noqa', 'no_lines', 'no_punct',
                    'no_whitespace', 'no_whitespace_eol', 'extract'):
         if args.__dict__[option]:
             po_check.set_check(option.lstrip('no_'),

--- a/tests/fr_errors.po
+++ b/tests/fr_errors.po
@@ -48,6 +48,7 @@ msgstr "Test 2 sur deux lignes.\nLigne 2.\nLigne 3."
 msgid "Tested 1."
 msgstr "Testé 1"
 
+#, noqa
 msgid "Tested 2"
 msgstr "Testé 2."
 

--- a/tests/test_msgcheck.py
+++ b/tests/test_msgcheck.py
@@ -96,6 +96,17 @@ class TestMsgCheck(unittest.TestCase):
         # the file has 11 errors (with the fuzzy string)
         self.assertEqual(len(result[0][1]), 11)
 
+    def test_checks_noqa(self):
+        """Test checks on a gettext file ignoring `noqa`-commented lines."""
+        po_check = PoCheck()
+        po_check.set_check('skip_noqa', True)
+        result = po_check.check_files([local_path('fr_errors.po')])
+        # be sure we have one file in result
+        self.assertEqual(len(result), 1)
+
+        # the file has 9 errors (`noqa` was skipped)
+        self.assertEqual(len(result[0][1]), 9)
+
     def test_replace_formatters_c(self):
         """Test removal of formatters in a C string."""
         self.assertEqual(replace_formatters('%s', 'c'), '')


### PR DESCRIPTION
HI @flashcode 

As we discussed in https://github.com/flashcode/msgcheck/issues/2 I've added check that looks for `# noqa` before every message and skips it, if flag `--skip-noqa` was added.

cc @codingjoe 