### PR TITLE
Fix noqa comment parsing

### DIFF
--- a/msgcheck/po.py
+++ b/msgcheck/po.py
@@ -350,7 +350,7 @@ class PoFile(object):
                     match = re.search(r'([a-z-]+)-format', line, re.IGNORECASE)
                     fmt = match.group(1) if match else None
                 if line.startswith('#'):
-                    noqa = 'noqa' in line
+                    noqa = noqa or 'noqa' in line
                     continue
                 if line.startswith('msg'):
                     match = re.match(


### PR DESCRIPTION
Previously the noqa parser would reset the noqa variable each comment line.
This lead to msgcheck only recognizing noqa comments if they were the last comment line before the message.

With this change the noqa comment can be any comment line for a given message.