### PR TITLE
Ref #12 -- Add support for Chinese full-stop (句號)

### DIFF
--- a/msgcheck/po.py
+++ b/msgcheck/po.py
@@ -180,8 +180,8 @@ class PoMessage(object):
                 continue
             puncts = [(':', ':'), (';', ';'), (',', ','), ('...', '...')]
             # special symbols in some languages
-            if language.startswith('ja'):
-                puncts.append(('.', '。'))
+            if language[:2] in ['ja', 'zh']:
+                puncts.append(('.', u'。'))
             else:
                 puncts.append(('.', '.'))
             for punctid, punctstr in puncts:
@@ -195,15 +195,15 @@ class PoMessage(object):
                     break
                 if match_id and not match_str:
                     errors.append(
-                        PoReport('end punctuation: "{0}" in string, '
-                                 '"{1}" not in translation'
+                        PoReport(u'end punctuation: "{0}" in string, '
+                                 u'"{1}" not in translation'
                                  ''.format(punctid, punctstr),
                                  'punct', self.filename, self.line, mid, mstr))
                     break
                 if not match_id and match_str:
                     errors.append(
-                        PoReport('end punctuation: "{0}" in translation, '
-                                 '"{1}" not in string'
+                        PoReport(u'end punctuation: "{0}" in translation, '
+                                 u'"{1}" not in string'
                                  ''.format(punctstr, punctid),
                                  'punct', self.filename, self.line, mid, mstr))
                     break


### PR DESCRIPTION
This was a rather simple fix, since there already was an exception implemented for Japanese, I simply extended it.
We could also add support for the Chinese ellipsis  …… (six dots with occupying two spaces). That I can add a second commit to do so.

If you are ok with the implementation, I'll add some test cases.